### PR TITLE
Implemented new generic type HTTPResponse, allowing for status code to be returned alongside data in each operation

### DIFF
--- a/src/operations/collections/index.ts
+++ b/src/operations/collections/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
-import { CollectionTypes } from "../../types/index.js"
+import { CollectionTypes, type HTTPResponse } from '../../types/index.js'
+import assert from 'assert'
 
 export class CollectionOperations {
     private client: AxiosInstance
@@ -11,174 +12,215 @@ export class CollectionOperations {
 
     async create(
         params: CollectionTypes.CollectionCreateParams
-    ): Promise<null | CollectionTypes.CollectionCreateResponse> {
+    ): Promise<HTTPResponse<null | CollectionTypes.CollectionCreateResponse>> {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'create', ...params })
             )
-            const data: CollectionTypes.CollectionCreateResponse = res.data;
+            const data: CollectionTypes.CollectionCreateResponse = res.data
             if (!data.created) {
-                console.error(`Failed to create collection: '${params.lpath}' already exists`)
-            }
-            else
-                console.info(`Collection '${params.lpath}' created successfully`)
-            return data
+                console.error(
+                    `Failed to create collection: '${params.lpath}' already exists`
+                )
+            } else
+                console.info(
+                    `Collection '${params.lpath}' created successfully`
+                )
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError) {
-                console.error(`Failed to create collection '${params.lpath}': ${error.message}`)
-            }
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to create collection '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove(
         params: CollectionTypes.CollectionRemoveParams
-    ): Promise<null | CollectionTypes.CollectionRemoveResponse> {
+    ): Promise<HTTPResponse<null | CollectionTypes.CollectionRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'remove', ...params })
             )
             console.log(`Collection '${params.lpath}' removed successfully`)
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.log(`Failed to remove collection '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.log(
+                `Failed to remove collection '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async stat(
         params: CollectionTypes.CollectionStatParams
-    ): Promise<null | CollectionTypes.CollectionStatResponse> {
+    ): Promise<HTTPResponse<null | CollectionTypes.CollectionStatResponse>> {
         try {
             const res = await this.client.get('/collections', {
                 params: { op: 'stat', ...params },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to retrieve information for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to retrieve information for '${params.lpath}': ${error.message}`
+            )
+            return {
+                status: error.response?.status!,
+                data: null,
+            }
         }
     }
 
     async list(
         params: CollectionTypes.CollectionListParams
-    ): Promise<null | CollectionTypes.CollectionListResponse> {
+    ): Promise<HTTPResponse<null | CollectionTypes.CollectionListResponse>> {
         try {
             const res = await this.client.get('/collections', {
                 params: { op: 'list', ...params },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
             console.log(error)
-            if (error instanceof AxiosError)
-                console.error(`Failed to retrieve list for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to retrieve list for '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async set_permission(
         params: CollectionTypes.CollectionSetPermissionParams
-    ): Promise<null | CollectionTypes.CollectionSetPermissionResponse> {
+    ): Promise<
+        HTTPResponse<null | CollectionTypes.CollectionSetPermissionResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'set_permission', ...params })
             )
             console.log(`Permission for '${params['entity-name']}' set`)
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to set permission for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to set permission for '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async set_inheritance(
         params: CollectionTypes.CollectionSetInheritanceParams
-    ): Promise<null | CollectionTypes.CollectionSetInheritanceResponse> {
+    ): Promise<
+        HTTPResponse<null | CollectionTypes.CollectionSetInheritanceResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'set_inheritance', ...params })
             )
-            console.log(`Inheritance for '${params.lpath}' ${params.enable ? "enabled" : "disabled"}`)
-            return res.data
+            console.log(
+                `Inheritance for '${params.lpath}' ${
+                    params.enable ? 'enabled' : 'disabled'
+                }`
+            )
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to set inheritance for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to set inheritance for '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_permissions(
         params: CollectionTypes.CollectionModifyPermissionsParams
-    ): Promise<null | CollectionTypes.CollectionModifyPermissionsResponse> {
+    ): Promise<
+        HTTPResponse<null | CollectionTypes.CollectionModifyPermissionsResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'modify_permissions', ...params })
             )
-            console.log(`Permissions for '${params.lpath}' successfully modified`)
-            return res.data
+            console.log(
+                `Permissions for '${params.lpath}' successfully modified`
+            )
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to modify permissions for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to modify permissions for '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_metadata(
         params: CollectionTypes.CollectionModifyMetadataParams
-    ): Promise<null | CollectionTypes.CollectionModifyMetadataResponse> {
+    ): Promise<
+        HTTPResponse<null | CollectionTypes.CollectionModifyMetadataResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'modify_metadata', ...params })
             )
             console.log(`Metadata for '${params.lpath}' successfully modified`)
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to modify metadata for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to modify metadata for '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async rename(
         params: CollectionTypes.CollectionRenameParams
-    ): Promise<null | CollectionTypes.CollectionRenameResponse> {
+    ): Promise<HTTPResponse<null | CollectionTypes.CollectionRenameResponse>> {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'rename', ...params })
             )
-            console.log(`'${params['old-lpath']}' successfully renamed to '${params['new-lpath']}'`)
-            return res.data
+            console.log(
+                `'${params['old-lpath']}' successfully renamed to '${params['new-lpath']}'`
+            )
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to rename '${params["old-lpath"]}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to rename '${params['old-lpath']}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async touch(
         params: CollectionTypes.CollectionTouchParams
-    ): Promise<null | CollectionTypes.CollectionTouchResponse> {
+    ): Promise<HTTPResponse<null | CollectionTypes.CollectionTouchResponse>> {
         try {
             const res = await this.client.post(
                 '/collections',
                 toURLSearchParams({ op: 'touch', ...params })
             )
             console.log(`Updated mtime for '${params.lpath}' successfully`)
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error(`Failed to update mtime for '${params.lpath}': ${error.message}`)
-            return null
+            assert(error instanceof AxiosError)
+            console.error(
+                `Failed to update mtime for '${params.lpath}': ${error.message}`
+            )
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/data_objects/index.ts
+++ b/src/operations/data_objects/index.ts
@@ -1,7 +1,8 @@
 import { AxiosError, type AxiosInstance } from 'axios'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
-import { DataObjectTypes } from "../../types/index.js"
+import { DataObjectTypes, type HTTPResponse } from '../../types/index.js'
 import { toFormData } from '../../utils/toFormData.js'
+import assert from 'assert'
 
 export class DataObjectOperations {
     private client: AxiosInstance
@@ -12,7 +13,7 @@ export class DataObjectOperations {
 
     async touch(
         params: DataObjectTypes.DataObjectTouchParams
-    ): Promise<null | DataObjectTypes.DataObjectTouchResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectTouchResponse>> {
         try {
             const res = await this.client.post(
                 '/data-objects',
@@ -21,170 +22,178 @@ export class DataObjectOperations {
             console.log(
                 `Successfully created or updated mtime of '${params.lpath}'`
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove(
         params: DataObjectTypes.DataObjectRemoveParams
-    ): Promise<null | DataObjectTypes.DataObjectRemoveResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'remove', ...params })
             )
             console.log(`Successfully removed data object '${params.lpath}'`)
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async calculate_checksum(
         params: DataObjectTypes.DataObjectCalculateChecksumParams
-    ): Promise<null | DataObjectTypes.DataObjectCalculateChecksumResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectCalculateChecksumResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'calculate_checksum', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async verify_checksum(
         params: DataObjectTypes.DataObjectVerifyChecksumParams
-    ): Promise<null | DataObjectTypes.DataObjectVerifyChecksumResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectVerifyChecksumResponse>
+    > {
         try {
             const res = await this.client.get('/data-objects', {
                 params: { op: 'verify_checksum', ...params },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async stat(
         params: DataObjectTypes.DataObjectStatParams
-    ): Promise<null | DataObjectTypes.DataObjectStatResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectStatResponse>> {
         try {
             const res = await this.client.get('/data-objects', {
                 params: { op: 'stat', ...params },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async rename(
         params: DataObjectTypes.DataObjectRenameParams
-    ): Promise<null | DataObjectTypes.DataObjectRenameResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectRenameResponse>> {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'rename', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async copy(
         params: DataObjectTypes.DataObjectCopyParams
-    ): Promise<null | DataObjectTypes.DataObjectCopyResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectCopyResponse>> {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'copy', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async replicate(
         params: DataObjectTypes.DataObjectReplicateParams
-    ): Promise<null | DataObjectTypes.DataObjectReplicateResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectReplicateResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'replicate', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async trim(
         params: DataObjectTypes.DataObjectTrimParams
-    ): Promise<null | DataObjectTypes.DataObjectTrimResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectTrimResponse>> {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'trim', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async register(
         params: DataObjectTypes.DataObjectRegisterParams
-    ): Promise<null | DataObjectTypes.DataObjectRegisterResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectRegisterResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'register', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     // GET request
     async read(
         params: DataObjectTypes.DataObjectReadParams
-    ): Promise<null | DataObjectTypes.DataObjectReadResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectReadResponse>> {
         try {
             const res = await this.client.get('/data-objects', {
                 params: { op: 'read', ...params },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
@@ -200,7 +209,7 @@ export class DataObjectOperations {
 
     async write(
         params: DataObjectTypes.DataObjectWriteParams
-    ): Promise<null | DataObjectTypes.DataObjectWriteResponse> {
+    ): Promise<HTTPResponse<null | DataObjectTypes.DataObjectWriteResponse>> {
         try {
             const res = await this.client.post(
                 '/data-objects',
@@ -211,107 +220,119 @@ export class DataObjectOperations {
                     },
                 }
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async parallel_write_init(
         params: DataObjectTypes.DataObjectParallelWriteInitParams
-    ): Promise<null | DataObjectTypes.DataObjectParallelWriteInitResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectParallelWriteInitResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'parallel_write_init', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async parallel_write_shutdown(
         params: DataObjectTypes.DataObjectParallelWriteShutdownParams
-    ): Promise<null | DataObjectTypes.DataObjectParallelWriteShutdownResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectParallelWriteShutdownResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'parallel_write_shutdown', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_metadata(
         params: DataObjectTypes.DataObjectModifyMetadataParams
-    ): Promise<null | DataObjectTypes.DataObjectModifyMetadataResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectModifyMetadataResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'modify_metadata', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async set_permission(
         params: DataObjectTypes.DataObjectSetPermissionParams
-    ): Promise<null | DataObjectTypes.DataObjectSetPermissionResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectSetPermissionResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'set_permission', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_permissions(
         params: DataObjectTypes.DataObjectModifyPermissionsParams
-    ): Promise<null | DataObjectTypes.DataObjectModifyPermissionsResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectModifyPermissionsResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'modify_permissions', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_replica(
         params: DataObjectTypes.DataObjectModifyReplicaParams
-    ): Promise<null | DataObjectTypes.DataObjectModifyReplicaResponse> {
+    ): Promise<
+        HTTPResponse<null | DataObjectTypes.DataObjectModifyReplicaResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/data-objects',
                 toURLSearchParams({ op: 'modify_replica', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/query/index.ts
+++ b/src/operations/query/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
-import { QueryTypes } from "../../types/index.js"
+import { QueryTypes, type HTTPResponse } from '../../types/index.js'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
+import assert from 'assert'
 
 export class QueryOperations {
     private client: AxiosInstance
@@ -11,7 +12,7 @@ export class QueryOperations {
 
     async execute_genquery(
         params: QueryTypes.ExecuteGenqueryParams
-    ): Promise<null | QueryTypes.ExecuteGenqueryResponse> {
+    ): Promise<HTTPResponse<null | QueryTypes.ExecuteGenqueryResponse>> {
         try {
             const res = await this.client.get('/query', {
                 params: {
@@ -19,17 +20,17 @@ export class QueryOperations {
                     ...params,
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async execute_specific_query(
         params: QueryTypes.ExecuteSpecificQueryParams
-    ): Promise<null | QueryTypes.ExecuteSpecificQueryResponse> {
+    ): Promise<HTTPResponse<null | QueryTypes.ExecuteSpecificQueryResponse>> {
         try {
             const res = await this.client.get('/query', {
                 params: {
@@ -37,17 +38,17 @@ export class QueryOperations {
                     ...params,
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async add_specific_query(
         params: QueryTypes.AddSpecificQueryParams
-    ): Promise<null | QueryTypes.AddSpecificQueryResponse> {
+    ): Promise<HTTPResponse<null | QueryTypes.AddSpecificQueryResponse>> {
         try {
             const res = await this.client.post(
                 '/query',
@@ -56,17 +57,17 @@ export class QueryOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove_specific_query(
         params: QueryTypes.RemoveSpecificQueryParams
-    ): Promise<null | QueryTypes.RemoveSpecificQueryResponse> {
+    ): Promise<HTTPResponse<null | QueryTypes.RemoveSpecificQueryResponse>> {
         try {
             const res = await this.client.post(
                 '/query',
@@ -75,11 +76,11 @@ export class QueryOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/resources/index.ts
+++ b/src/operations/resources/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
-import { ResourceTypes } from "../../types/index.js"
+import { ResourceTypes, type HTTPResponse } from '../../types/index.js'
+import assert from 'assert'
 
 export class ResourceOperations {
     private client: AxiosInstance
@@ -11,112 +12,114 @@ export class ResourceOperations {
 
     async create(
         params: ResourceTypes.ResourceCreateParams
-    ): Promise<null | ResourceTypes.ResourceCreateResponse> {
+    ): Promise<HTTPResponse<null | ResourceTypes.ResourceCreateResponse>> {
         try {
             const res = await this.client.post(
                 '/resources',
                 toURLSearchParams({ op: 'create', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove(
         params: ResourceTypes.ResourceRemoveParams
-    ): Promise<null | ResourceTypes.ResourceRemoveResponse> {
+    ): Promise<HTTPResponse<null | ResourceTypes.ResourceRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/resources',
                 toURLSearchParams({ op: 'remove', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async add_child(
         params: ResourceTypes.ResourceAddChildParams
-    ): Promise<null | ResourceTypes.ResourceAddChildResponse> {
+    ): Promise<HTTPResponse<null | ResourceTypes.ResourceAddChildResponse>> {
         try {
             const res = await this.client.post(
                 '/resources',
                 toURLSearchParams({ op: 'add_child', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove_child(
         params: ResourceTypes.ResourceRemoveChildParams
-    ): Promise<null | ResourceTypes.ResourceRemoveChildResponse> {
+    ): Promise<HTTPResponse<null | ResourceTypes.ResourceRemoveChildResponse>> {
         try {
             const res = await this.client.post(
                 '/resources',
                 toURLSearchParams({ op: 'remove_child', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async rebalance(
         params: ResourceTypes.ResourceRebalanceParams
-    ): Promise<null | ResourceTypes.ResourceRebalanceResponse> {
+    ): Promise<HTTPResponse<null | ResourceTypes.ResourceRebalanceResponse>> {
         try {
             const res = await this.client.post(
                 '/resources',
                 toURLSearchParams({ op: 'rebalance', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async stat(
         params: ResourceTypes.ResourceStatParams
-    ): Promise<null | ResourceTypes.ResourceStatResponse> {
+    ): Promise<HTTPResponse<null | ResourceTypes.ResourceStatResponse>> {
         try {
             const res = await this.client.get('/resources', {
                 params: { op: 'stat', ...params },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_metadata(
         params: ResourceTypes.ResourceModifyMetadataParams
-    ): Promise<null | ResourceTypes.ResourceModifyMetadataResponse> {
+    ): Promise<
+        HTTPResponse<null | ResourceTypes.ResourceModifyMetadataResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/resources',
                 toURLSearchParams({ op: 'modify_metadata', ...params })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/rules/index.ts
+++ b/src/operations/rules/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
-import { RuleTypes } from "../../types/index.js"
+import { RuleTypes, type HTTPResponse } from '../../types/index.js'
+import assert from 'assert'
 
 export class RuleOperations {
     private client: AxiosInstance
@@ -9,24 +10,26 @@ export class RuleOperations {
         this.client = client
     }
 
-    async list_rule_engines(): Promise<null | RuleTypes.ListRuleEnginesResponse> {
+    async list_rule_engines(): Promise<
+        HTTPResponse<null | RuleTypes.ListRuleEnginesResponse>
+    > {
         try {
             const res = await this.client.get('/rules', {
                 params: {
                     op: 'list_rule_engines',
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async execute(
         params: RuleTypes.RuleExecuteParams
-    ): Promise<null | RuleTypes.RuleExecuteResponse> {
+    ): Promise<HTTPResponse<null | RuleTypes.RuleExecuteResponse>> {
         try {
             const res = await this.client.post(
                 '/rules',
@@ -35,17 +38,17 @@ export class RuleOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove_delay_rule(
         params: RuleTypes.RuleRemoveDelayRuleParams
-    ): Promise<null | RuleTypes.RuleRemoveDelayRuleResponse> {
+    ): Promise<HTTPResponse<null | RuleTypes.RuleRemoveDelayRuleResponse>> {
         try {
             const res = await this.client.post(
                 '/rules',
@@ -54,11 +57,11 @@ export class RuleOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/tickets/index.ts
+++ b/src/operations/tickets/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
-import { TicketTypes } from "../../types/index.js"
+import { TicketTypes, type HTTPResponse } from '../../types/index.js'
+import assert from 'assert'
 
 export class TicketOperations {
     private client: AxiosInstance
@@ -11,7 +12,7 @@ export class TicketOperations {
 
     async create(
         params: TicketTypes.TicketCreateParams
-    ): Promise<null | TicketTypes.TicketCreateResponse> {
+    ): Promise<HTTPResponse<null | TicketTypes.TicketCreateResponse>> {
         try {
             const res = await this.client.post(
                 '/tickets',
@@ -20,17 +21,17 @@ export class TicketOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove(
         params: TicketTypes.TicketRemoveParams
-    ): Promise<null | TicketTypes.TicketRemoveResponse> {
+    ): Promise<HTTPResponse<null | TicketTypes.TicketRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/tickets',
@@ -39,11 +40,11 @@ export class TicketOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/users_groups/index.ts
+++ b/src/operations/users_groups/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
-import { UserGroupTypes } from "../../types/index.js"
+import { UserGroupTypes, type HTTPResponse } from '../../types/index.js'
+import assert from 'assert'
 
 export class UserGroupOperations {
     private client: AxiosInstance
@@ -11,7 +12,7 @@ export class UserGroupOperations {
 
     async create_user(
         params: UserGroupTypes.UserCreateParams
-    ): Promise<null | UserGroupTypes.UserCreateResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserCreateResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -20,17 +21,17 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove_user(
         params: UserGroupTypes.UserRemoveParams
-    ): Promise<null | UserGroupTypes.UserRemoveResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -39,17 +40,17 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async set_password(
         params: UserGroupTypes.UserSetPasswordParams
-    ): Promise<null | UserGroupTypes.UserSetPasswordResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserSetPasswordResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -58,17 +59,17 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async set_user_type(
         params: UserGroupTypes.UserSetTypeParams
-    ): Promise<null | UserGroupTypes.UserSetTypeResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserSetTypeResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -77,17 +78,17 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async create_group(
         params: UserGroupTypes.GroupCreateParams
-    ): Promise<null | UserGroupTypes.GroupCreateResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.GroupCreateResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -96,17 +97,17 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove_group(
         params: UserGroupTypes.GroupRemoveParams
-    ): Promise<null | UserGroupTypes.GroupRemoveResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.GroupRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -115,17 +116,17 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async add_to_group(
         params: UserGroupTypes.UserAddToGroupParams
-    ): Promise<null | UserGroupTypes.UserAddToGroupResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserAddToGroupResponse>> {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -134,17 +135,19 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove_from_group(
         params: UserGroupTypes.UserRemoveFromGroupParams
-    ): Promise<null | UserGroupTypes.UserRemoveFromGroupResponse> {
+    ): Promise<
+        HTTPResponse<null | UserGroupTypes.UserRemoveFromGroupResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -153,47 +156,49 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
-    async users(): Promise<null | UserGroupTypes.UsersResponse> {
+    async users(): Promise<HTTPResponse<null | UserGroupTypes.UsersResponse>> {
         try {
             const res = await this.client.get('/users-groups', {
                 params: {
                     op: 'users',
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
-    async groups(): Promise<null | UserGroupTypes.GroupsResponse> {
+    async groups(): Promise<
+        HTTPResponse<null | UserGroupTypes.GroupsResponse>
+    > {
         try {
             const res = await this.client.get('/users-groups', {
                 params: {
                     op: 'groups',
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async is_member_of_group(
         params: UserGroupTypes.UserMemberOfGroupParams
-    ): Promise<null | UserGroupTypes.UserMemberOfGroupResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserMemberOfGroupResponse>> {
         try {
             const res = await this.client.get('/users-groups', {
                 params: {
@@ -201,17 +206,17 @@ export class UserGroupOperations {
                     ...params,
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async stat(
         params: UserGroupTypes.UserGroupStatParams
-    ): Promise<null | UserGroupTypes.UserGroupStatResponse> {
+    ): Promise<HTTPResponse<null | UserGroupTypes.UserGroupStatResponse>> {
         try {
             const res = await this.client.get('/users-groups', {
                 params: {
@@ -219,17 +224,19 @@ export class UserGroupOperations {
                     ...params,
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify_metadata(
         params: UserGroupTypes.UserGroupModifyMetadata
-    ): Promise<null | UserGroupTypes.UserGroupModifyMetadataResponse> {
+    ): Promise<
+        HTTPResponse<null | UserGroupTypes.UserGroupModifyMetadataResponse>
+    > {
         try {
             const res = await this.client.post(
                 '/users-groups',
@@ -238,11 +245,11 @@ export class UserGroupOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/operations/zones/index.ts
+++ b/src/operations/zones/index.ts
@@ -1,6 +1,7 @@
 import { AxiosError, type AxiosInstance } from 'axios'
-import { ZoneTypes } from "../../types/index.js"
+import { ZoneTypes, type HTTPResponse } from '../../types/index.js'
 import { toURLSearchParams } from '../../utils/toURLSearchParams.js'
+import assert from 'assert'
 
 export class ZoneOperations {
     private client: AxiosInstance
@@ -11,7 +12,7 @@ export class ZoneOperations {
 
     async add(
         params: ZoneTypes.ZoneAddParams
-    ): Promise<null | ZoneTypes.ZoneAddResponse> {
+    ): Promise<HTTPResponse<null | ZoneTypes.ZoneAddResponse>> {
         try {
             const res = await this.client.post(
                 '/zones',
@@ -20,17 +21,17 @@ export class ZoneOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async remove(
         params: ZoneTypes.ZoneRemoveParams
-    ): Promise<null | ZoneTypes.ZoneRemoveResponse> {
+    ): Promise<HTTPResponse<null | ZoneTypes.ZoneRemoveResponse>> {
         try {
             const res = await this.client.post(
                 '/zones',
@@ -39,17 +40,17 @@ export class ZoneOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
     async modify(
         params: ZoneTypes.ZoneModifyParams
-    ): Promise<null | ZoneTypes.ZoneModifyResponse> {
+    ): Promise<HTTPResponse<null | ZoneTypes.ZoneModifyResponse>> {
         try {
             const res = await this.client.post(
                 '/zones',
@@ -58,26 +59,26 @@ export class ZoneOperations {
                     ...params,
                 })
             )
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 
-    async report(): Promise<null | ZoneTypes.ZoneReportResponse> {
+    async report(): Promise<HTTPResponse<null | ZoneTypes.ZoneReportResponse>> {
         try {
             const res = await this.client.get('/zones', {
                 params: {
                     op: 'report',
                 },
             })
-            return res.data
+            return { status: res.status, data: res.data }
         } catch (error) {
-            if (error instanceof AxiosError)
-                console.error('Error: ', error.response?.statusText)
-            return null
+            assert(error instanceof AxiosError)
+            console.error('Error: ', error.response?.statusText)
+            return { status: error.response?.status!, data: null }
         }
     }
 }

--- a/src/tests/collections.test.ts
+++ b/src/tests/collections.test.ts
@@ -14,24 +14,28 @@ describe('CollectionTests', () => {
         const res = await api.collections.create({
             lpath: lpath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Stat for a collection', async () => {
         const res = await api.collections.stat({
-            lpath: lpath,
+            lpath: `/${zoneName}/home`,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        console.log(res)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('List contents of a collection', async () => {
         const res = await api.collections.list({
             lpath: `/${zoneName}/home`,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Set permission of a collection', async () => {
@@ -40,8 +44,9 @@ describe('CollectionTests', () => {
             'entity-name': 'alice',
             permission: 'read',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Set inheritance of a collection', async () => {
@@ -49,8 +54,9 @@ describe('CollectionTests', () => {
             lpath: lpath,
             enable: 1,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Modify permissions of a collection', async () => {
@@ -63,9 +69,10 @@ describe('CollectionTests', () => {
                 },
             ],
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
-        expect(res?.irods_response.failed_operation).toEqual({})
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
+        expect(res.data?.irods_response.failed_operation).toEqual({})
     })
 
     test('Modify metadata of a collection', async () => {
@@ -80,9 +87,10 @@ describe('CollectionTests', () => {
                 },
             ],
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
-        expect(res?.irods_response.failed_operation).toEqual({})
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
+        expect(res.data?.irods_response.failed_operation).toEqual({})
     })
 
     test('Rename a collection', async () => {
@@ -90,23 +98,26 @@ describe('CollectionTests', () => {
             'old-lpath': lpath,
             'new-lpath': renamedLPath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Touch a collection', async () => {
         const res = await api.collections.touch({
             lpath: renamedLPath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove a collection', async () => {
         const res = await api.collections.remove({
             lpath: renamedLPath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/data_objects.test.ts
+++ b/src/tests/data_objects.test.ts
@@ -1,4 +1,4 @@
-import type { IrodsResponse } from '../types/general_types.js'
+import type { HTTPResponse, IrodsResponse } from '../types/general_types.js'
 import fs from 'fs'
 
 import { createClientForTesting } from './setupTests.js'
@@ -20,8 +20,9 @@ describe('DataObjectTests', () => {
         const res = await api.data_objects.touch({
             lpath: lpath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     // https://nodejs.org/api/buffer.html#static-method-bufferfromarray
@@ -32,8 +33,9 @@ describe('DataObjectTests', () => {
             lpath: lpath,
             bytes: testBuffer,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Read data object', async () => {
@@ -41,7 +43,7 @@ describe('DataObjectTests', () => {
             lpath: lpath,
         })
         console.log(res)
-        expect(res).toBeTruthy()
+        expect(res.data).toBeTruthy()
     })
 
     test('Parallel write', async () => {
@@ -50,15 +52,16 @@ describe('DataObjectTests', () => {
             lpath: lpath,
             'stream-count': streamCount,
         })
-        parallelWriteHandle = initRes?.parallel_write_handle
-        expect(initRes).toBeTruthy()
-        expect(initRes?.irods_response.status_code).toEqual(0)
+        parallelWriteHandle = initRes.data?.parallel_write_handle
+        expect(initRes.data).toBeTruthy()
+        expect(initRes.status).toEqual(200)
+        expect(initRes.data?.irods_response.status_code).toEqual(0)
 
         if (!parallelWriteHandle) return
 
         // Parallel write
         let testBuffer: Buffer
-        let responses: Promise<IrodsResponse | null>[] = []
+        let responses: Promise<HTTPResponse<null | IrodsResponse>>[] = []
         for (let i = 0; i < streamCount; i++) {
             testBuffer = Buffer.from(`hello${i}`)
             let res = api.data_objects.write({
@@ -77,8 +80,9 @@ describe('DataObjectTests', () => {
         const shutdownRes = await api.data_objects.parallel_write_shutdown({
             'parallel-write-handle': parallelWriteHandle,
         })
-        expect(shutdownRes).toBeTruthy()
-        expect(shutdownRes?.irods_response.status_code).toEqual(0)
+        expect(shutdownRes.data).toBeTruthy()
+        expect(shutdownRes.status).toEqual(200)
+        expect(shutdownRes.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Modify metadata of a data object', async () => {
@@ -93,8 +97,9 @@ describe('DataObjectTests', () => {
                 },
             ],
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Set permission of a data object', async () => {
@@ -103,8 +108,9 @@ describe('DataObjectTests', () => {
             'entity-name': 'alice',
             permission: 'write',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Modify permissions of a data object', async () => {
@@ -117,32 +123,36 @@ describe('DataObjectTests', () => {
                 },
             ],
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Calculate checksum', async () => {
         const res = await api.data_objects.calculate_checksum({
             lpath: lpath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Verify checksum', async () => {
         const res = await api.data_objects.verify_checksum({
             lpath: lpath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Stat for data object', async () => {
         const res = await api.data_objects.stat({
             lpath: lpath,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Copy data object', async () => {
@@ -150,8 +160,9 @@ describe('DataObjectTests', () => {
             'src-lpath': lpath,
             'dst-lpath': `${baseLPath}/dataObject2.txt`,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Rename data object', async () => {
@@ -159,8 +170,9 @@ describe('DataObjectTests', () => {
             'old-lpath': `${baseLPath}/dataObject2.txt`,
             'new-lpath': `${baseLPath}/dataObjectCopy.txt`,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Replicate data object', async () => {
@@ -170,8 +182,9 @@ describe('DataObjectTests', () => {
             'dst-resource': 'wrapperResc',
         })
         console.log(res)
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     // Mutually exclusive fields of "replica-number" and "resource-hierarchy", at least 1 optional field must be filled
@@ -181,8 +194,9 @@ describe('DataObjectTests', () => {
             'replica-number': 1,
             'new-data-comments': 'test comment',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Trim data object', async () => {
@@ -190,8 +204,9 @@ describe('DataObjectTests', () => {
             lpath: lpath,
             'replica-number': 1,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Register data object', async () => {
@@ -218,8 +233,9 @@ describe('DataObjectTests', () => {
             console.log('Error deleting file: ', error)
         }
 
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove data object', async () => {
@@ -241,13 +257,16 @@ describe('DataObjectTests', () => {
             'no-trash': 1,
         })
 
-        expect(res1).toBeTruthy()
-        expect(res1?.irods_response.status_code).toEqual(0)
+        expect(res1.data).toBeTruthy()
+        expect(res1?.status).toEqual(200)
+        expect(res1.data?.irods_response.status_code).toEqual(0)
 
-        expect(res2).toBeTruthy()
-        expect(res2?.irods_response.status_code).toEqual(0)
+        expect(res2.data).toBeTruthy()
+        expect(res2.status).toEqual(200)
+        expect(res2.data?.irods_response.status_code).toEqual(0)
 
-        expect(res3).toBeTruthy()
-        expect(res3?.irods_response.status_code).toEqual(0)
+        expect(res3.data).toBeTruthy()
+        expect(res3.status).toEqual(200)
+        expect(res3.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/query.test.ts
+++ b/src/tests/query.test.ts
@@ -18,8 +18,9 @@ describe('QueryTests', () => {
         const res = await api.query.execute_genquery({
             query: genquery,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Add specific query', async () => {
@@ -27,8 +28,9 @@ describe('QueryTests', () => {
             name: specific_query_name,
             sql: specific_query,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Execute specific query', async () => {
@@ -36,16 +38,18 @@ describe('QueryTests', () => {
             name: specific_query_name,
         })
         console.log(res)
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
-        expect(res?.rows[0][0]).toEqual('200') // The token ID of rodsgroup is always 200.
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
+        expect(res.data?.rows[0][0]).toEqual('200') // The token ID of rodsgroup is always 200.
     })
 
     test('Remove specific query', async () => {
         const res = await api.query.remove_specific_query({
             name: specific_query_name,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/resource.test.ts
+++ b/src/tests/resource.test.ts
@@ -21,17 +21,19 @@ describe('ResourceTests', () => {
             host: host,
             'vault-path': vaultPath,
         })
-        expect(res1).toBeTruthy()
-        expect(res1?.irods_response.status_code).toEqual(0)
+        expect(res1.data).toBeTruthy()
+        expect(res1.status).toEqual(200)
+        expect(res1.data?.irods_response.status_code).toEqual(0)
 
         const res2 = await api.resources.create({
             name: childResc,
             type: 'unixfilesystem',
-            host: 'ip-172-31-12-211',
-            'vault-path': '/var/lib/irods/new_vault',
+            host: host,
+            'vault-path': vaultPath,
         })
-        expect(res2).toBeTruthy()
-        expect(res2?.irods_response.status_code).toEqual(0)
+        expect(res2.data).toBeTruthy()
+        expect(res2.status).toEqual(200)
+        expect(res2.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Modify resource metadata', async () => {
@@ -46,17 +48,19 @@ describe('ResourceTests', () => {
                 },
             ],
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Resource stats', async () => {
         const res = await api.resources.stat({
             name: parentResc,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
-        expect(res?.info).toBeTruthy()
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
+        expect(res.data?.info).toBeTruthy()
     })
 
     test('Add child to resource', async () => {
@@ -64,16 +68,18 @@ describe('ResourceTests', () => {
             'child-name': childResc,
             'parent-name': parentResc,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Rebalance resource', async () => {
         const res = await api.resources.rebalance({
             name: parentResc,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove child from resource', async () => {
@@ -81,8 +87,9 @@ describe('ResourceTests', () => {
             'child-name': childResc,
             'parent-name': parentResc,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove resource', async () => {
@@ -94,10 +101,12 @@ describe('ResourceTests', () => {
             name: childResc,
         })
 
-        expect(res1).toBeTruthy()
-        expect(res1?.irods_response.status_code).toEqual(0)
+        expect(res1.data).toBeTruthy()
+        expect(res1.status).toEqual(200)
+        expect(res1.data?.irods_response.status_code).toEqual(0)
 
-        expect(res2).toBeTruthy()
-        expect(res2?.irods_response.status_code).toEqual(0)
+        expect(res2.data).toBeTruthy()
+        expect(res2.status).toEqual(200)
+        expect(res2.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/rule.test.ts
+++ b/src/tests/rule.test.ts
@@ -7,8 +7,9 @@ describe('RuleTests', () => {
     test('List Rule Engines', async () => {
         const res = await api.rules.list_rule_engines()
         console.log(res)
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     // recommended to include rep-instance field
@@ -19,10 +20,11 @@ describe('RuleTests', () => {
             'rule-text': `writeLine("stdout", "${test_msg}")`,
         })
         console.log(res)
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
-        expect(res?.stderr).toBeFalsy()
-        expect(res?.stdout).toEqual(test_msg + '\n')
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
+        expect(res.data?.stderr).toBeFalsy()
+        expect(res.data?.stdout).toEqual(test_msg + '\n')
     })
 
     test('Remove delay rule', async () => {
@@ -31,8 +33,9 @@ describe('RuleTests', () => {
             'rep-instance': rep_instance,
             'rule-text': `delay("<INST_NAME>${rep_instance}</INST_NAME><PLUSET>1h</PLUSET>") { writeLine("serverLog", "iRODS HTTP API"); }`,
         })
-        expect(delayRes).toBeTruthy()
-        expect(delayRes?.irods_response.status_code).toEqual(0)
+        expect(delayRes.data).toBeTruthy()
+        expect(delayRes.status).toEqual(200)
+        expect(delayRes.data?.irods_response.status_code).toEqual(0)
 
         // Find the delay rule we just created.
         // This query assumes the test suite is running on a system where no other delay
@@ -40,16 +43,18 @@ describe('RuleTests', () => {
         const findDelayRuleRes = await api.query.execute_genquery({
             query: 'select max(RULE_EXEC_ID)',
         })
-        expect(findDelayRuleRes).toBeTruthy()
-        expect(findDelayRuleRes?.rows.length).toEqual(1)
+        expect(findDelayRuleRes.data).toBeTruthy()
+        expect(findDelayRuleRes.status).toEqual(200)
+        expect(findDelayRuleRes.data?.rows.length).toEqual(1)
 
         // Remove delay rule
-        let ruleID: string | undefined = findDelayRuleRes?.rows[0][0]
+        let ruleID: string | undefined = findDelayRuleRes.data?.rows[0][0]
         if (!ruleID) return
         const res = await api.rules.remove_delay_rule({
             'rule-id': parseInt(ruleID),
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/ticket.test.ts
+++ b/src/tests/ticket.test.ts
@@ -8,15 +8,17 @@ describe('TicketTests', () => {
         const createRes = await api.tickets.create({
             lpath: '/tempZone/home/rods',
         })
-        expect(createRes).toBeTruthy()
-        expect(createRes?.irods_response.status_code).toEqual(0)
-        expect(createRes?.ticket).toBeTruthy()
-        ticketName = createRes!.ticket
+        expect(createRes.data).toBeTruthy()
+        expect(createRes.status).toEqual(200)
+        expect(createRes.data?.irods_response.status_code).toEqual(0)
+        expect(createRes.data?.ticket).toBeTruthy()
+        ticketName = createRes.data!.ticket
 
         const removeRes = await api.tickets.remove({
             name: ticketName,
         })
         expect(removeRes).toBeTruthy()
-        expect(removeRes?.irods_response.status_code).toEqual(0)
+        expect(removeRes.status).toEqual(200)
+        expect(removeRes.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/user_group.test.ts
+++ b/src/tests/user_group.test.ts
@@ -13,8 +13,9 @@ describe('UserGroupTests', () => {
             zone: zoneName,
             'user-type': 'rodsuser',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Set user password', async () => {
@@ -23,8 +24,9 @@ describe('UserGroupTests', () => {
             zone: zoneName,
             'new-password': 'testPassword',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Set user type', async () => {
@@ -33,16 +35,18 @@ describe('UserGroupTests', () => {
             zone: zoneName,
             'new-user-type': 'rodsadmin',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Create group', async () => {
         const res = await api.users_groups.create_group({
             name: groupName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Add user to group', async () => {
@@ -51,8 +55,9 @@ describe('UserGroupTests', () => {
             group: groupName,
             zone: zoneName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Is user member of group', async () => {
@@ -61,8 +66,9 @@ describe('UserGroupTests', () => {
             group: groupName,
             zone: zoneName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove user from group', async () => {
@@ -71,20 +77,23 @@ describe('UserGroupTests', () => {
             group: groupName,
             zone: zoneName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('List users', async () => {
         const res = await api.users_groups.users()
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('List groups', async () => {
         const res = await api.users_groups.groups()
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Stat for a user or group', async () => {
@@ -92,8 +101,9 @@ describe('UserGroupTests', () => {
             name: userName,
             zone: zoneName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Modify metadata for a user or group', async () => {
@@ -108,8 +118,9 @@ describe('UserGroupTests', () => {
                 },
             ],
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove user', async () => {
@@ -117,15 +128,17 @@ describe('UserGroupTests', () => {
             name: userName,
             zone: zoneName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove group', async () => {
         const res = await api.users_groups.remove_group({
             name: groupName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/tests/zone.test.ts
+++ b/src/tests/zone.test.ts
@@ -10,8 +10,9 @@ describe('ZoneTests', () => {
             name: zoneName,
             comment: 'New test zone',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Modify zone', async () => {
@@ -20,21 +21,24 @@ describe('ZoneTests', () => {
             property: 'comment',
             value: 'Modified comment',
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Zone report', async () => {
         const res = await api.zones.report()
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 
     test('Remove zone', async () => {
         const res = await api.zones.remove({
             name: zoneName,
         })
-        expect(res).toBeTruthy()
-        expect(res?.irods_response.status_code).toEqual(0)
+        expect(res.data).toBeTruthy()
+        expect(res.status).toEqual(200)
+        expect(res.data?.irods_response.status_code).toEqual(0)
     })
 })

--- a/src/types/general_types.ts
+++ b/src/types/general_types.ts
@@ -53,6 +53,26 @@ export type IrodsResponse = {
     }
 }
 
+/* 
+    Generic type for wrapper responses, where T is a type parameter and can be used as follows:
+        -   async operation_function(): HTTPResponse<CollectionCreateResponse> {
+		        ...
+	        }
+    The data structure for the return type of operation_function will be equivalent to:
+        {
+            status: number,
+            data: {
+                irods_response: ...
+                created?: boolean
+            }
+        }
+*/
+
+export type HTTPResponse<T> = {
+    status: number
+    data: T
+}
+
 export type StatusFields = {
     http_status: number
     message: string


### PR DESCRIPTION
- Wrapped response type of each function in HTTPResponse - What used to be returned from the function (if not null) is now inside the data field of the new return type
- Adjusted unit tests to check for status code of 200 (in addition to everything else), all are passing